### PR TITLE
Use curvature drive instead of arcade drive.

### DIFF
--- a/src/main/java/frc/robot/commands/DriveWithGamepadCommand.java
+++ b/src/main/java/frc/robot/commands/DriveWithGamepadCommand.java
@@ -27,7 +27,12 @@ public class DriveWithGamepadCommand extends CommandBase {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    m_drive.arcadeDrive(-m_controller.getLeftY(),m_controller.getRightX());
+
+    double xSpeed = -m_controller.getLeftY();
+    double zRotation = m_controller.getRightX();
+    boolean quickTurn = m_controller.getLeftBumper();
+
+    m_drive.curvatureDrive(xSpeed, zRotation, quickTurn);
   }
   
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -4,6 +4,7 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
@@ -24,16 +25,24 @@ public class Drive extends SubsystemBase {
     m_leftFollower = new WPI_TalonFX(Constants.kDriveTalonLeftBId);
     m_leftFollower.follow(m_leftLeader);
 
-
     m_rightLeader = new WPI_TalonFX(Constants.kDriveTalonRightAId);
     m_rightFollower = new WPI_TalonFX(Constants.kDriveTalonRightBId);
     m_rightFollower.follow(m_rightLeader);
-    m_rightFollower.setInverted(true);
-    m_rightLeader.setInverted(true);
 
+    m_leftLeader.setInverted(false);
+    m_leftFollower.setInverted(false);
+    m_rightLeader.setInverted(true);
+    m_rightFollower.setInverted(true);
+
+    // Use brake mode to stop our robot coasting.
+    m_leftLeader.setNeutralMode(NeutralMode.Brake);
+    m_leftFollower.setNeutralMode(NeutralMode.Brake);
+    m_rightLeader.setNeutralMode(NeutralMode.Brake);
+    m_rightFollower.setNeutralMode(NeutralMode.Brake);
+    
     m_drive = new DifferentialDrive(m_leftLeader, m_rightLeader);
   }
-  
+
 
   @Override
   public void periodic() {
@@ -43,6 +52,13 @@ public class Drive extends SubsystemBase {
   public void arcadeDrive(double forward, double rotate){
     m_drive.arcadeDrive(forward, rotate);
   }
+
+  public void curvatureDrive(double xSpeed, double zRotation, boolean allowTurnInPlace){
+    xSpeed = Math.copySign(xSpeed*xSpeed, xSpeed)*0.5;
+    zRotation = Math.copySign(zRotation*zRotation, zRotation);
+    m_drive.curvatureDrive(xSpeed, zRotation, allowTurnInPlace);
+  }
+
 
   public void stop(){
     m_drive.stopMotor();


### PR DESCRIPTION
Use curvature drive instead of arcade drive.

Also enable break mode on the drive motors to help prevent the robot from coasting. 