### PR TITLE
Upgrade WPILib and CTRE libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2022.2.1"
+    id "edu.wpi.first.GradleRIO" version "2022.3.1"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.20.2",
+    "version": "5.21.1",
     "frcYear": 2022,
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
@@ -12,19 +12,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.20.2"
+            "version": "5.21.1"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.20.2"
+            "version": "5.21.1"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -34,7 +34,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -46,7 +46,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simTalonSRX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simTalonFX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -70,7 +70,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simVictorSPX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -82,7 +82,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simPigeonIMU",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -94,7 +94,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simCANCoder",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -108,7 +108,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -120,7 +120,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -132,7 +132,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -144,7 +144,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_Phoenix_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "api-cpp-sim",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_PhoenixSim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -172,7 +172,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_PhoenixCCISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -186,7 +186,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simTalonSRX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -200,7 +200,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simTalonFX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -214,7 +214,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simVictorSPX",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -228,7 +228,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simPigeonIMU",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -242,7 +242,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "simCANCoder",
-            "version": "5.20.2",
+            "version": "5.21.1",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
Upgrade WPILib to `2022.3.1`. Requires a new RoboRIO Image `2022_v4.0` see: https://github.com/wpilibsuite/allwpilib/releases/tag/v2022.3.1
<img width="717" alt="image" src="https://user-images.githubusercontent.com/1790831/154823867-0801a5f5-eea5-4ec9-a0e9-82a9f6911d76.png">

This is the new required image pr R701 in the latest game manual. 

CTRE Changes:
```
Phoenix Framework 5.21.1 (Feb 04 2022):

	NOTE: It is highly recommended that CANivore users update to this version or newer due to the fixes and improvements it contains.

	Phoenix Installer (5.21.1.0): Fixed an issue where the necessary vc redistributable for Windows CANivore Diagnostic server was missing
	Phoenix Installer (5.21.1.0): Fixed an issue where CANcoder simulation libraries were not placed by the installer

	Phoenix Libraries: Performance improvements for CANivore
	Phoenix Libraries: Updated PigeonIMU/Pigeon2 classes to be compatible with WPILib Gyro Sendable type
	Phoenix Libraries: Added RobotBuilder components for CANdle and Pigeon 2.0
	Phoenix LabVIEW (2022_v4): Fixed an issue with Open VIs that could cause multiple Phoenix instances to load

	Phoenix Tuner (1.8.0): Added Mount Orientation page for Pigeon 2.0

	CANdle Firmware (22.0.1.0): Fixed an issue where the animation speed did not perform as expected
	CANdle Firmware (22.0.1.0): Fixed an issue where the Fire animation did not work
	Pigeon 2.0 Firmware (22.6.1.0): Initial Firmware release
	CANivore Firmware (22.1.0.1): Initial firmware release

	Known Issues:
		CANdle Firmware: Larson Animation at speed 0.75 and higher does not function correctly


```